### PR TITLE
Fix Makefile commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,21 +19,21 @@ venv-clean:
 	rm -rf $(VENV_NAME)
 
 source:
-	source $(PWD)/.env.sh &&
+	. $(PWD)/.env.sh
 
 # Reset the database migrations and import data from the `Landesrepositories`.
 generate-tokens:
-	source $(PWD)/.env.sh && \
+	. $(PWD)/.env.sh && \
 	python -m sammelrepository generate-tokens
 
 # Reset the database migrations and import data from the `Landesrepositories`.
 reset-db:
-	source $(PWD)/.env.sh && \
+	. $(PWD)/.env.sh && \
 	python -m sammelrepository resetdb
 
 # Run the app in local environment
 run-local:
-	source $(PWD)/.env.sh && \
+	. $(PWD)/.env.sh && \
 	uvicorn sammelrepository.main:create_app --factory --reload --log-config=./config/log_conf.yaml
 
 # Clean up all compiled Python files and build artifacts
@@ -52,5 +52,5 @@ pyright:
 	poetry run pyright $(SRC)
 
 test:
-	source $(PWD)/.env.sh && \
+	. $(PWD)/.env.sh && \
 	poetry run pytest


### PR DESCRIPTION
## Summary
- use POSIX-compatible '.' to source environment file
- fix run-local and other targets to use '.' instead of 'source'

## Testing
- `make test` *(fails: cannot open .env.sh)*
- `make lint` *(fails: Poetry could not find pyproject.toml)*

------
https://chatgpt.com/codex/tasks/task_b_684f495f4f24832eb7bb943f43c3b3d5